### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,11 +11,11 @@ runs:
   using: "composite"
   steps:
     - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@v1
+      uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
 
     - name: Cache Just
       id: just-cache
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cargo/bin/just
         key: just-${{ inputs.just-version }}-${{ runner.os }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/contract-sizes.yml
+++ b/.github/workflows/contract-sizes.yml
@@ -9,8 +9,8 @@ jobs:
     name: Build & check sizes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
       - run: forge build --sizes

--- a/.github/workflows/deploy-hoodi-fork.yml
+++ b/.github/workflows/deploy-hoodi-fork.yml
@@ -19,7 +19,7 @@ jobs:
           DONT_SET_CHAIN_ID: true
           HARDFORK: prague
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
       - uses: ./.github/actions/setup

--- a/.github/workflows/integration-hoodi.yml
+++ b/.github/workflows/integration-hoodi.yml
@@ -16,7 +16,7 @@ jobs:
       FACTORY_ADDRESS: "0xd05ebf24a340ece8b8fb53a170f1171dcd02b4d9"
       MELLOW_STRATEGY_FACTORY: "0x0b860bfFDA72D214Dc8aC98bEcd8D1cd55307561"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
 

--- a/.github/workflows/integration-mainnet.yml
+++ b/.github/workflows/integration-mainnet.yml
@@ -16,7 +16,7 @@ jobs:
       FACTORY_ADDRESS: "0x3f221b8E5bC098cC6C23611BEeacaeCfD77e1587"
       MELLOW_STRATEGY_FACTORY: "0x8Fac09FD82F031D390B94622E2E4baBf16Fd2236"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
 

--- a/.github/workflows/integration-scratch.yml
+++ b/.github/workflows/integration-scratch.yml
@@ -20,7 +20,7 @@ jobs:
           HARDFORK: prague
           DONT_SET_CHAIN_ID: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
       - uses: ./.github/actions/setup

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,6 @@ jobs:
     name: Check formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
       - run: forge fmt --check

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ jobs:
     name: Run unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
       - uses: ./.github/actions/setup


### PR DESCRIPTION
Adds a Dependabot configuration for weekly grouped dependency updates:

- `github-actions`: weekly, grouped, 7-day cooldown

Also pins all workflow actions to commit hashes and bumps them to latest releases:

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6.0.3 |
| foundry-rs/foundry-toolchain | v1 | v1.8.0 |
| actions/cache | v4 | v5.0.5 |