### PR TITLE
ci: bind setup-just version via env before shell

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,4 +23,6 @@ runs:
     - name: Install Just
       if: steps.just-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: cargo install "just@${{ inputs.just-version }}"
+      env:
+        JUST_VERSION: ${{ inputs.just-version }}
+      run: cargo install "just@${JUST_VERSION}"


### PR DESCRIPTION
## Summary
The Setup composite action interpolated `inputs.just-version` directly into a `run:` script (`cargo install "just@${{ inputs.just-version }}"`). Move the value into `env:` and expand `"just@${JUST_VERSION}"` in the shell instead.

Same pattern as the sibling change in `lidofinance/csm-widget`.

## Test plan
- [ ] Workflow using Setup still installs Just on cache miss
- [ ] Cache key `just-${{ inputs.just-version }}-…` unchanged


Made with [Cursor](https://cursor.com)